### PR TITLE
Update action to use PAT instead of GitHub Token

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Write application tag into environment variable
         run: |
-          curl -L -i -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repositories/547182049/environments/${{ inputs.workspace }}/variables/TF_VAR_CPD_IMAGE_TAG -d '{"name": "TF_VAR_CPD_IMAGE_TAG", "value": "${{ inputs.tag }}"}'
+          curl -L -i -X PATCH -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repositories/547182049/environments/${{ inputs.workspace }}/variables/TF_VAR_CPD_IMAGE_TAG -d '{"name": "TF_VAR_CPD_IMAGE_TAG", "value": "${{ inputs.tag }}"}'
 
       - name: Sign out of Azure
         run: |


### PR DESCRIPTION
GitHub token doesn't have permissions to write to variables, so will use a PAT token.