### PR TITLE
feat: Add Google Analytics Attribute data-track-label with page url

### DIFF
--- a/Childrens-Social-Care-CPD-Tests/Childrens-Social-Care-CPD-Tests.csproj
+++ b/Childrens-Social-Care-CPD-Tests/Childrens-Social-Care-CPD-Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.16" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Childrens-Social-Care-CPD-Tests/Childrens-Social-Care-CPD-Tests.csproj
+++ b/Childrens-Social-Care-CPD-Tests/Childrens-Social-Care-CPD-Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.16" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/ContentLinkRendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/ContentLinkRendererTests.cs
@@ -2,6 +2,7 @@
 using Childrens_Social_Care_CPD.Contentful.Renderers;
 using FluentAssertions;
 using Microsoft.Extensions.WebEncoders.Testing;
+using Moq;
 using NUnit.Framework;
 using System.IO;
 
@@ -9,7 +10,13 @@ namespace Childrens_Social_Care_CPD_Tests.Contentful.Renderers;
 
 public class ContentLinkRendererTests
 {
-    private readonly IRendererWithOptions<ContentLink> _sut = new ContentLinkRenderer();
+    private readonly IRendererWithOptions<ContentLink> _sut;
+
+    public ContentLinkRendererTests()
+    {
+        Mock<IContentLinkContext> mockContentLinkContext = new Mock<IContentLinkContext>();
+        _sut = new ContentLinkRenderer(mockContentLinkContext.Object);
+    }
 
     [TestCase("http://foo", "http://foo")]
     [TestCase("https://foo", "https://foo")]
@@ -31,7 +38,8 @@ public class ContentLinkRendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be($"<a class=\"HtmlEncode[[govuk-link]]\" href=\"HtmlEncode[[{expectedUri}]]\">HtmlEncode[[Foo]]</a>");
+        actual.Should().Be($"<a class=\"HtmlEncode[[govuk-link]]\" data-track-label=\"\" href=\"HtmlEncode[[{expectedUri}]]\">HtmlEncode[[Foo]]</a>");
+        
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/ContentLinkRendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/ContentLinkRendererTests.cs
@@ -2,7 +2,7 @@
 using Childrens_Social_Care_CPD.Contentful.Renderers;
 using FluentAssertions;
 using Microsoft.Extensions.WebEncoders.Testing;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using System.IO;
 
@@ -14,8 +14,8 @@ public class ContentLinkRendererTests
 
     public ContentLinkRendererTests()
     {
-        Mock<IContentLinkContext> mockContentLinkContext = new Mock<IContentLinkContext>();
-        _sut = new ContentLinkRenderer(mockContentLinkContext.Object);
+        var mockContentLinkContext = Substitute.For<IContentLinkContext>();
+        _sut = new ContentLinkRenderer(mockContentLinkContext);
     }
 
     [TestCase("http://foo", "http://foo")]

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/HyperlinkRendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/HyperlinkRendererTests.cs
@@ -2,6 +2,7 @@
 using Contentful.Core.Models;
 using FluentAssertions;
 using Microsoft.Extensions.WebEncoders.Testing;
+using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
@@ -10,7 +11,13 @@ namespace Childrens_Social_Care_CPD_Tests.Contentful.Renderers;
 
 public class HyperlinkRendererTests
 {
-    private readonly HyperlinkRenderer _sut = new();
+    private readonly HyperlinkRenderer _sut;
+
+    public HyperlinkRendererTests()
+    {
+        Mock<IContentLinkContext> mockContentLinkContext = new Mock<IContentLinkContext>();
+        _sut = new HyperlinkRenderer(mockContentLinkContext.Object);
+    }
 
     [Test]
     public void HyperlinkToHtml_Returns_Anchor()
@@ -34,7 +41,7 @@ public class HyperlinkRendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<a class=\"HtmlEncode[[govuk-link]]\" href=\"HtmlEncode[[Bar]]\">HtmlEncode[[Foo]]</a>");
+        actual.Should().Be("<a class=\"HtmlEncode[[govuk-link]]\" data-track-label=\"\" href=\"HtmlEncode[[Bar]]\">HtmlEncode[[Foo]]</a>");
     }
 
     [Test]
@@ -57,6 +64,6 @@ public class HyperlinkRendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<a class=\"HtmlEncode[[govuk-link]]\" href=\"HtmlEncode[[Bar]]\"></a>");
+        actual.Should().Be("<a class=\"HtmlEncode[[govuk-link]]\" data-track-label=\"\" href=\"HtmlEncode[[Bar]]\"></a>");
     }
 }

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/HyperlinkRendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/HyperlinkRendererTests.cs
@@ -2,7 +2,7 @@
 using Contentful.Core.Models;
 using FluentAssertions;
 using Microsoft.Extensions.WebEncoders.Testing;
-using Moq;
+using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
@@ -15,8 +15,8 @@ public class HyperlinkRendererTests
 
     public HyperlinkRendererTests()
     {
-        Mock<IContentLinkContext> mockContentLinkContext = new Mock<IContentLinkContext>();
-        _sut = new HyperlinkRenderer(mockContentLinkContext.Object);
+        var mockContentLinkContext = Substitute.For<IContentLinkContext>();
+        _sut = new HyperlinkRenderer(mockContentLinkContext);
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD/Contentful/Contexts/ContentLinkContext.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Contexts/ContentLinkContext.cs
@@ -1,0 +1,14 @@
+﻿using Childrens_Social_Care_CPD.Contentful.Renderers;
+
+namespace Childrens_Social_Care_CPD.Contentful.Contexts
+{
+    public class ContentLinkContext : IContentLinkContext
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        public ContentLinkContext(IHttpContextAccessor httpContextAccessor) 
+        { 
+            _httpContextAccessor = httpContextAccessor;
+        }
+        public string Path => _httpContextAccessor.HttpContext?.Request.Path;
+    }
+}

--- a/Childrens-Social-Care-CPD/Contentful/Renderers/ContentLinkRenderer.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Renderers/ContentLinkRenderer.cs
@@ -4,8 +4,18 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace Childrens_Social_Care_CPD.Contentful.Renderers;
 
+interface IContentLinkContext
+{
+    string Path { get; }
+}
+
 internal class ContentLinkRenderer : IRendererWithOptions<ContentLink>
 {
+    private readonly IContentLinkContext _context;
+    public ContentLinkRenderer(IContentLinkContext contentLinkContext) 
+    { 
+        _context = contentLinkContext;
+    }
     public IHtmlContent Render(ContentLink item, RendererOptions options = null)
     {
         var tagBuilder = new TagBuilder("a");
@@ -23,6 +33,7 @@ internal class ContentLinkRenderer : IRendererWithOptions<ContentLink>
         {
             tagBuilder.AddCssClass(options.Css);
         }
+        tagBuilder.Attributes.Add("data-track-label", _context.Path);
         tagBuilder.InnerHtml.Append(item.Name);
         return tagBuilder;
     }

--- a/Childrens-Social-Care-CPD/Contentful/Renderers/HyperlinkRenderer.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Renderers/HyperlinkRenderer.cs
@@ -6,12 +6,18 @@ namespace Childrens_Social_Care_CPD.Contentful.Renderers;
 
 internal class HyperlinkRenderer : IRenderer<Hyperlink>
 {
+    private readonly IContentLinkContext _context;
+    public HyperlinkRenderer(IContentLinkContext contentLinkContext)
+    {
+        _context = contentLinkContext;
+    }
     public IHtmlContent Render(Hyperlink item)
     {
         var linkText = (item.Content.FirstOrDefault() as Text)?.Value;
         var anchor = new TagBuilder("a");
         anchor.AddCssClass("govuk-link");
         anchor.Attributes.Add("href", item.Data.Uri);
+        anchor.Attributes.Add("data-track-label", _context.Path);
         anchor.InnerHtml.SetContent(linkText);
         return anchor;
     }

--- a/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
+++ b/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Childrens_Social_Care_CPD.Configuration;
 using Childrens_Social_Care_CPD.Contentful;
+using Childrens_Social_Care_CPD.Contentful.Contexts;
 using Childrens_Social_Care_CPD.Contentful.Renderers;
 using Childrens_Social_Care_CPD.Core.Resources;
 using Childrens_Social_Care_CPD.DataAccess;
@@ -51,6 +52,8 @@ public static class WebApplicationBuilderExtensions
             client.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
             return client;
         });
+
+        builder.Services.AddScoped<IContentLinkContext, ContentLinkContext>();
 
         // Register all the IRender<T> & IRenderWithOptions<T> implementations in the assembly
         var assemblyTypes = System.Reflection.Assembly.GetExecutingAssembly().GetTypes();


### PR DESCRIPTION
Add Google Analytics Attribute data-track-label with page url so that pages where JavaScript Void appears can be identified