### PR TITLE
Revert Content Security Policy Header on App GW

### DIFF
--- a/Terraform/appgw.tf
+++ b/Terraform/appgw.tf
@@ -230,7 +230,7 @@ resource "azurerm_application_gateway" "appgw" {
 
       response_header_configuration {
         header_name  = "Content-Security-Policy"
-        header_value = "upgrade-insecure-requests; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; default-src 'self';"
+        header_value = "upgrade-insecure-requests; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none';"
       }
 
       response_header_configuration {


### PR DESCRIPTION
Reverting change as policy is too restrictive on main app.