### PR TITLE
Terraform change to disable public access on the applications

### DIFF
--- a/Terraform/appgw.tf
+++ b/Terraform/appgw.tf
@@ -59,7 +59,7 @@ resource "azurerm_application_gateway" "appgw" {
   backend_http_settings {
     name                                = var.http_setting_name[terraform.workspace]
     pick_host_name_from_backend_address = true
-    cookie_based_affinity               = "Disabled"
+    cookie_based_affinity               = "Enabled"
     path                                = "/"
     port                                = 80
     protocol                            = "Http"

--- a/Terraform/appgw.tf
+++ b/Terraform/appgw.tf
@@ -59,7 +59,7 @@ resource "azurerm_application_gateway" "appgw" {
   backend_http_settings {
     name                                = var.http_setting_name[terraform.workspace]
     pick_host_name_from_backend_address = true
-    cookie_based_affinity               = "Enabled"
+    cookie_based_affinity               = "Disabled"
     path                                = "/"
     port                                = 80
     protocol                            = "Http"

--- a/Terraform/application.tf
+++ b/Terraform/application.tf
@@ -10,10 +10,11 @@ resource "azurerm_service_plan" "service-plan" {
 
 # Definition of the linux web app for the service
 resource "azurerm_linux_web_app" "linux-web-app" {
-  name                = var.web_app_name[terraform.workspace]
-  resource_group_name = data.azurerm_resource_group.rg.name
-  location            = data.azurerm_resource_group.rg.location
-  service_plan_id     = azurerm_service_plan.service-plan.id
+  name                          = var.web_app_name[terraform.workspace]
+  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = data.azurerm_resource_group.rg.location
+  service_plan_id               = azurerm_service_plan.service-plan.id
+  public_network_access_enabled = false
 
   app_settings = {
     CPD_GOOGLEANALYTICSTAG               = var.cpd_googleanalyticstag

--- a/Terraform/grafana.tf
+++ b/Terraform/grafana.tf
@@ -31,10 +31,11 @@ resource "azurerm_storage_share" "gffileshare" {
 
 # Definition of the Grafana linux web app for the service
 resource "azurerm_linux_web_app" "grafana-web-app" {
-  name                = var.grafana_webapp_name[terraform.workspace]
-  resource_group_name = data.azurerm_resource_group.rg.name
-  location            = data.azurerm_resource_group.rg.location
-  service_plan_id     = azurerm_service_plan.service-plan-gf.id
+  name                          = var.grafana_webapp_name[terraform.workspace]
+  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = data.azurerm_resource_group.rg.location
+  service_plan_id               = azurerm_service_plan.service-plan-gf.id
+  public_network_access_enabled = false
 
   app_settings = {
     DOCKER_ENABLE_CI                    = "true"


### PR DESCRIPTION
Azure seems to have defaulted to public access on applications, explicitly setting it to disabled. 
Also enabled cookie based affinity on the Application Gateway