### PR TITLE
Force the Firewall Policy on the App Gateway

### DIFF
--- a/Terraform/appgw.tf
+++ b/Terraform/appgw.tf
@@ -29,7 +29,8 @@ resource "azurerm_application_gateway" "appgw" {
   }
 
   # A firewall policy that should only be populated for Load-Test and Prod environments 
-  firewall_policy_id = var.appgw_tier[terraform.workspace] == "WAF_v2" ? azurerm_web_application_firewall_policy.fwpol.id : null
+  firewall_policy_id                = var.appgw_tier[terraform.workspace] == "WAF_v2" ? azurerm_web_application_firewall_policy.fwpol.id : null
+  force_firewall_policy_association = true
 
   gateway_ip_configuration {
     name      = var.gateway_ip_configuration[terraform.workspace]


### PR DESCRIPTION
If we don't force the firewall policy on the application gateway then it won't come up.  This is because we need to replace a prevention policy with a detection policy.  There is no security risk in this as prevention policies are on each of the two paths.