### PR TITLE
CI: removing TODO comment from search config item

### DIFF
--- a/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
@@ -60,7 +60,7 @@ public interface IApplicationConfiguration
     [RequiredForEnvironment(ApplicationEnvironment.All, Hidden = false)]
     string GoogleTagManagerKey { get; }
 
-    [RequiredForEnvironment(ApplicationEnvironment.None, Hidden = false)] // TODO: when released, set the env to ALL
+    [RequiredForEnvironment(ApplicationEnvironment.None, Hidden = false)]
     string SearchApiKey { get; }
 
     [RequiredForEnvironment(ApplicationEnvironment.None, Hidden = false)] // TODO: when released, set the env to ALL


### PR DESCRIPTION
Removing a TODO comment on a Search functionality config setting.