### PR TITLE
ci: ensure required scripts calculated correctly on deployments after the first

### DIFF
--- a/Contentful-Schema/utils/get-required-migrations.js
+++ b/Contentful-Schema/utils/get-required-migrations.js
@@ -28,6 +28,7 @@ files.every(filename => {
         requiredMigrations = files.slice(version - 1);
         return false;
     }
+    return true;
 });
 
 core.setOutput('required-migrations', requiredMigrations);


### PR DESCRIPTION
A bug in one of the migration scripts meant that required migration script detection only worked reliably on the first deployment. Now fixed.