### PR TITLE
fix: apply three-quarter page width style to hero banner

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_HeroBanner.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_HeroBanner.cshtml
@@ -5,7 +5,7 @@
 <section class="app-section-beta app-section-beta__blue govuk-!-margin-bottom-8">
     <div class="dfe-width-container">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-three-quarters-from-desktop">
                 <h1 class="body-header-font" data-testid="homepage-header">@Model.Title</h1>
                 <p class="govuk-body govuk-!-font-size-24 body-header-font">@Model.Text</p>
             </div>


### PR DESCRIPTION
Applies the same content-width styling used in the page banner to the hero banner - that had been missed from the first run at this work.