### PR TITLE
fix: backed out previous change - restored PAT to allow subsequent workflows to be triggered

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,5 +27,5 @@ jobs:
           node-version: "lts/*"
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: npx semantic-release@21


### PR DESCRIPTION
Restores the Create Release workflow to how it was before the earlier change.  Using the github automatic token authentication means that workflows will not invoke other workflows - resulting in our release pipeline breaking down.