### PR TITLE
fix: remove resources and learning tab from views/feature flags

### DIFF
--- a/Childrens-Social-Care-CPD/Configuration/Features/Features.cs
+++ b/Childrens-Social-Care-CPD/Configuration/Features/Features.cs
@@ -2,7 +2,6 @@
 
 public static class Features
 {
-    public const string ResourcesAndLearning = "resources-learning";
     public const string FeedbackControl = "feedback-control";
     public const string EmployerStandards = "employer-standards";
     public const string AgencyResources = "agency-resources";

--- a/Childrens-Social-Care-CPD/Views/Shared/_ErrorLayout.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_ErrorLayout.cshtml
@@ -80,17 +80,6 @@
                             </svg>
                         </a>
                     </li>
-                    @if (featuresConfig.IsEnabled(Features.ResourcesAndLearning))
-                    {
-                        <li class="dfe-header__navigation-item" id="mmi-resources">
-                            <a class="dfe-header__navigation-link" href="/resources-learning">
-                                Resources and learning
-                                <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-                                    <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                                </svg>
-                            </a>
-                        </li>
-                    }
                     @if (featuresConfig.IsEnabled(Features.EmployerStandards))
                     {
                         <li class="dfe-header__navigation-item" id="mmi-employerStandards">

--- a/Childrens-Social-Care-CPD/Views/Shared/_Header.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_Header.cshtml
@@ -57,10 +57,6 @@
                     RenderMenuItem("developmentProgrammes", "Development programmes", "development-programmes", category == "Development programmes");
                     RenderMenuItem("exploreRoles", "Explore roles", "explore-roles", category == "Explore roles");
 
-                    if (featuresConfig.IsEnabled(Features.ResourcesAndLearning))
-                    {
-                        RenderMenuItem("resources", "Resources and learning", "resources-learning", category == "Resources");
-                    }
                     if (featuresConfig.IsEnabled(Features.EmployerStandards))
                     {
                         RenderMenuItem("employerStandards", "Employer standards", "employer-standards", category == "Employer standards");


### PR DESCRIPTION
Removes support for the Resources and Learning tab from the header and error views, and removes the feature flag that controlled that tab.  That tab is the search tab, and the views and controllers were already removed, so this is just tidying up things that were missed from the previous PR.