### PR TITLE
Sfsw 3043 Remove code & config for data protection

### DIFF
--- a/Childrens-Social-Care-CPD-Tests/Configuration/ApplicationConfigurationTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Configuration/ApplicationConfigurationTests.cs
@@ -38,11 +38,7 @@ public class ApplicationConfigurationTests
         get
         {
             // Set values
-            yield return ("CPD_AZURE_DATA_PROTECTION_CONTAINER_NAME", (ApplicationConfiguration sut) => sut.AzureDataProtectionContainerName, "foo", "foo");
             yield return ("CPD_AZURE_ENVIRONMENT", (ApplicationConfiguration sut) => sut.AzureEnvironment, "foo", "foo");
-            yield return ("CPD_AZURE_MANAGED_IDENTITY_ID", (ApplicationConfiguration sut) => sut.AzureManagedIdentityId, "foo", "foo");
-            yield return ("CPD_AZURE_STORAGE_ACCOUNT", (ApplicationConfiguration sut) => sut.AzureStorageAccount, "foo", "foo");
-            yield return ("CPD_AZURE_STORAGE_ACCOUNT_URI_FORMAT_STRING", (ApplicationConfiguration sut) => sut.AzureStorageAccountUriFormatString, "foo", "foo");
             yield return ("CPD_CLARITY", (ApplicationConfiguration sut) => sut.ClarityProjectId, "foo", "foo");
             yield return ("CPD_DELIVERY_KEY", (ApplicationConfiguration sut) => sut.ContentfulDeliveryApiKey, "foo", "foo");
             yield return ("CPD_CONTENTFUL_ENVIRONMENT", (ApplicationConfiguration sut) => sut.ContentfulEnvironment, "foo", "foo");
@@ -59,11 +55,7 @@ public class ApplicationConfigurationTests
             yield return ("CPD_SEARCH_INDEX_NAME", (ApplicationConfiguration sut) => sut.SearchIndexName, "foo", "foo");
 
             // Default values
-            yield return ("CPD_AZURE_DATA_PROTECTION_CONTAINER_NAME", (ApplicationConfiguration sut) => sut.AzureDataProtectionContainerName, null, null);
             yield return ("CPD_AZURE_ENVIRONMENT", (ApplicationConfiguration sut) => sut.AzureEnvironment, null, null);
-            yield return ("CPD_AZURE_MANAGED_IDENTITY_ID", (ApplicationConfiguration sut) => sut.AzureManagedIdentityId, null, null);
-            yield return ("CPD_AZURE_STORAGE_ACCOUNT", (ApplicationConfiguration sut) => sut.AzureStorageAccount, null, null);
-            yield return ("CPD_AZURE_STORAGE_ACCOUNT_URI_FORMAT_STRING", (ApplicationConfiguration sut) => sut.AzureStorageAccountUriFormatString, null, null);
             yield return ("CPD_CLARITY", (ApplicationConfiguration sut) => sut.ClarityProjectId, null, null);
             yield return ("CPD_DELIVERY_KEY", (ApplicationConfiguration sut) => sut.ContentfulDeliveryApiKey, null, null);
             yield return ("CPD_CONTENTFUL_ENVIRONMENT", (ApplicationConfiguration sut) => sut.ContentfulEnvironment, null, null);

--- a/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerBreadcrumbTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerBreadcrumbTests.cs
@@ -9,7 +9,6 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.Extensions.Azure;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Childrens-Social-Care-CPD/Childrens-Social-Care-CPD.csproj
+++ b/Childrens-Social-Care-CPD/Childrens-Social-Care-CPD.csproj
@@ -14,12 +14,9 @@
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="contentful.aspnetcore" Version="7.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.11" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
   </ItemGroup>
   <ItemGroup>

--- a/Childrens-Social-Care-CPD/Configuration/ApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD/Configuration/ApplicationConfiguration.cs
@@ -4,11 +4,7 @@ public class ApplicationConfiguration(IConfiguration configuration) : IApplicati
 {
     public string AppInsightsConnectionString => configuration["CPD_INSTRUMENTATION_CONNECTIONSTRING"];
     public string AppVersion => configuration["VCS-TAG"];
-    public string AzureDataProtectionContainerName => configuration["CPD_AZURE_DATA_PROTECTION_CONTAINER_NAME"];
     public string AzureEnvironment => configuration["CPD_AZURE_ENVIRONMENT"];
-    public string AzureManagedIdentityId => configuration["CPD_AZURE_MANAGED_IDENTITY_ID"];
-    public string AzureStorageAccount => configuration["CPD_AZURE_STORAGE_ACCOUNT"];
-    public string AzureStorageAccountUriFormatString => configuration["CPD_AZURE_STORAGE_ACCOUNT_URI_FORMAT_STRING"];
     public string ClarityProjectId => configuration["CPD_CLARITY"];
     public string ContentfulDeliveryApiKey => configuration["CPD_DELIVERY_KEY"];
     public string ContentfulEnvironment => configuration["CPD_CONTENTFUL_ENVIRONMENT"];

--- a/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
@@ -10,20 +10,8 @@ public interface IApplicationConfiguration
     [RequiredForEnvironment(ApplicationEnvironment.All, Hidden = false, Obfuscate = false)]
     string AppVersion { get; }
 
-    [RequiredForEnvironment(ApplicationEnvironment.Production, Hidden = false, Obfuscate = false)]
-    string AzureDataProtectionContainerName { get; }
-
     [RequiredForEnvironment(ApplicationEnvironment.All, Hidden = false, Obfuscate = false)]
     string AzureEnvironment { get; }
-
-    [RequiredForEnvironment(ApplicationEnvironment.Production, Hidden = false)]
-    string AzureManagedIdentityId { get; }
-
-    [RequiredForEnvironment(ApplicationEnvironment.Production, Hidden = false)]
-    string AzureStorageAccount { get; }
-
-    [RequiredForEnvironment(ApplicationEnvironment.Production, Hidden = false, Obfuscate = false)]
-    string AzureStorageAccountUriFormatString { get; }
 
     [RequiredForEnvironment(ApplicationEnvironment.Production, Hidden = false)]
     string ClarityProjectId { get; }

--- a/Childrens-Social-Care-CPD/Contentful/Navigation/PathwaysNavigationHelper.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Navigation/PathwaysNavigationHelper.cs
@@ -1,7 +1,4 @@
-using System.Reflection.Metadata.Ecma335;
-using Azure;
 using Childrens_Social_Care_CPD.Contentful.Models;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Childrens_Social_Care_CPD.Contentful.Navigation;
 

--- a/Childrens-Social-Care-CPD/Controllers/ContentController.cs
+++ b/Childrens-Social-Care-CPD/Controllers/ContentController.cs
@@ -4,8 +4,6 @@ using Childrens_Social_Care_CPD.Contentful.Navigation;
 using Childrens_Social_Care_CPD.Models;
 using Contentful.Core.Search;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
 
 namespace Childrens_Social_Care_CPD.Controllers;
 
@@ -30,7 +28,7 @@ public class ContentController(ICpdContentfulClient cpdClient) : Controller
         CancellationToken ct)
     {
         var trailItem = new KeyValuePair<string, string>(
-            page.BreadcrumbText.IsNullOrEmpty() ? 
+            String.IsNullOrEmpty(page.BreadcrumbText) ?
                 page.Title : 
                 page.BreadcrumbText,
             page.Id);

--- a/Childrens-Social-Care-CPD/Controllers/CookieController.cs
+++ b/Childrens-Social-Care-CPD/Controllers/CookieController.cs
@@ -12,7 +12,6 @@ public class CookieController(ICpdContentfulClient cpdClient, ICookieHelper cook
     private const string _pageName = "cookies";
 
     [HttpPost]
-    [ValidateAntiForgeryToken]
     [Route("/cookies/setpreferences")]
     public IActionResult SetPreferences(string consentValue, string sourcePage = null, bool fromCookies = false)
     {

--- a/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
+++ b/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
@@ -7,7 +7,6 @@ using Childrens_Social_Care_CPD.Contentful.Renderers;
 using Contentful.AspNetCore;
 using Contentful.Core.Configuration;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.Extensions.Logging.AzureAppServices;
 using System.Diagnostics;
@@ -84,9 +83,6 @@ public static class WebApplicationBuilderExtensions
 
         AddHealthChecks(builder.Services);
         Console.WriteLine($"After AddHealthChecks: {sw.ElapsedMilliseconds}ms");
-
-        AddDataProtection(builder.Services, applicationConfiguration, sw);
-        Console.WriteLine($"After AddDataProtection: {sw.ElapsedMilliseconds}ms");
     }
 
     private static void AddLogging(WebApplicationBuilder builder, ApplicationConfiguration applicationConfiguration)
@@ -136,24 +132,5 @@ public static class WebApplicationBuilderExtensions
 #pragma warning disable CA1861 // Avoid constant arrays as arguments
         services.AddHealthChecks().AddCheck<ConfigurationHealthCheck>("Configuration Health Check", tags: new[] { "configuration" });
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
-    }
-
-    private static void AddDataProtection(IServiceCollection services, ApplicationConfiguration applicationConfiguration, Stopwatch sw)
-    {
-        if (!string.IsNullOrEmpty(applicationConfiguration.AzureDataProtectionContainerName))
-        {
-            var url = string.Format(applicationConfiguration.AzureStorageAccountUriFormatString,
-                applicationConfiguration.AzureStorageAccount,
-                applicationConfiguration.AzureDataProtectionContainerName);
-
-            var managedIdentityCredential = new ManagedIdentityCredential(clientId: applicationConfiguration.AzureManagedIdentityId);
-            Console.WriteLine($"After AddDataProtection:new ManagedIdentityCredential: {sw.ElapsedMilliseconds}ms");
-
-            var blobUri = new Uri($"{url}/data-protection");
-            services
-                .AddDataProtection()
-                .SetApplicationName($"Childrens-Social-Care-CPD-{applicationConfiguration.AzureEnvironment}")
-                .PersistKeysToAzureBlobStorage(blobUri, managedIdentityCredential);
-        }
     }
 }

--- a/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
+++ b/Childrens-Social-Care-CPD/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Azure.Identity;
-using Childrens_Social_Care_CPD.Configuration;
+﻿using Childrens_Social_Care_CPD.Configuration;
 using Childrens_Social_Care_CPD.Configuration.Features;
 using Childrens_Social_Care_CPD.Contentful;
 using Childrens_Social_Care_CPD.Contentful.Contexts;


### PR DESCRIPTION
Removes the code and configurations that supported the use of a DataProtection storage account, along with a managed identity that allowed access to that SA.