### PR TITLE
Navigation menu regression tests

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_SubPageLayout.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_SubPageLayout.cshtml
@@ -19,7 +19,7 @@
 
 <div class="govuk-width-container dfe-width-container">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-quarter">
+        <div class="govuk-grid-column-one-quarter" data-testid="navigation-menu-container">
             @await RenderSectionAsync("SideMenu", required: true)
         </div>
         <div class="govuk-grid-column-three-quarters">

--- a/browser-tests/regression-tests/tests/hero-banner.spec.ts
+++ b/browser-tests/regression-tests/tests/hero-banner.spec.ts
@@ -41,3 +41,46 @@ test.describe('Hero Banner', () => {
     
 });
 
+test.describe('Hero Banner on Mobile Viewport', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.setViewportSize({
+            width: 640,
+            height: 480
+        });
+        await page.goto('/demo/hero-banner/example');
+    });
+
+    test.describe('Title', () => {
+        test('Has correct styles', async ({ page }) => {
+            const title = page.getByTestId('hero-banner-title');
+            await expect(title).toHaveCSS('margin-bottom', '20px');
+            await expect(title).toHaveCSS('margin-top', '0px');
+            await expect(title).toHaveCSS('font-weight', '700');
+            await expect(title).toHaveCSS('font-size', '32px');
+            await expect(title).toHaveCSS('line-height', '42.6666px');
+        });
+    });
+
+    test.describe('Text', () => {
+        test('Has correct styles', async ({ page }) => {
+            const text = page.getByTestId('hero-banner-text');
+            await expect(text).toHaveCSS('margin-bottom', '15px');
+            await expect(text).toHaveCSS('margin-top', '0px');
+            await expect(text).toHaveCSS('font-weight', '400');
+            await expect(text).toHaveCSS('font-size', '18px');
+            await expect(text).toHaveCSS('line-height', '20px');
+        });
+    });
+
+    test.describe('Container', () => {
+        test('Has correct styles', async ({ page }) => {
+            const container = page.getByTestId('hero-banner-container');
+            await expect(container).toHaveCSS('margin-bottom', '30px');
+            await expect(container).toHaveCSS('padding-top', '40px');
+            await expect(container).toHaveCSS('padding-bottom', '35px');
+            await expect(container).toHaveCSS('background-color', 'rgb(52, 124, 169)');
+        });
+    });
+
+    
+});

--- a/browser-tests/regression-tests/tests/nav-menu.spec.ts
+++ b/browser-tests/regression-tests/tests/nav-menu.spec.ts
@@ -1,0 +1,80 @@
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation Menu with Header', () => {
+    let elements = {};
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/demo/navigation-menu');
+
+        elements['container'] = page.getByTestId('navigation-menu-container');
+        elements['header'] = elements['container'].locator('h2');
+        elements['nav-container'] = elements['container'].locator('nav');
+        elements['nav-link-containers'] = elements['container'].locator('li');
+        elements['inactive-nav-element-container'] = elements['nav-link-containers'].locator('nth=0');
+        elements['inactive-nav-element'] = elements['inactive-nav-element-container'].locator('a');
+        elements['active-nav-element-container'] = elements['nav-link-containers'].locator('nth=2');
+        elements['active-nav-element'] = elements['active-nav-element-container'].locator('a');
+    });
+
+    test('Containers', async ({ page }) => {
+
+        // the container for the whole nav
+        await expect(elements['container']).toHaveCSS('padding-left', '15px');
+        await expect(elements['container']).toHaveCSS('padding-right', '15px');
+
+        // the nav header
+        await expect(elements['header']).toHaveCSS('margin-bottom', '24px');
+        await expect(elements['header']).toHaveCSS('font-weight', '700');
+        await expect(elements['header']).toHaveCSS('font-size', '24px');
+
+        // the container for the collection of nav itmes
+        await expect(elements['nav-container']).toHaveCSS('margin-left', '-15px');
+        await expect(elements['nav-container']).toHaveCSS('padding-left', '15px');
+    });
+
+    test('Nav items', async ({ page }) => {
+
+        await expect(elements['nav-link-containers']).toHaveCount(16);
+
+        // an inactive (not current page) nav item
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(177, 180, 182)');
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('margin-bottom', '8px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('padding', '7px 30px 8px 10px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('margin-bottom', '5px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('cursor', 'pointer');
+        await expect(elements['inactive-nav-element']).toHaveCSS('font-weight', '400');
+
+        // hover styles for an inactive nav item
+        await elements['inactive-nav-element-container'].hover();
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(52, 124, 169)');
+    });
+
+    test('Active nav item', async ({ page }) => {
+
+        // an active (current page) nav item
+        await expect(elements['active-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(0, 58, 105)');
+        await expect(elements['active-nav-element-container']).toHaveCSS('margin-bottom', '8px');
+        await expect(elements['active-nav-element-container']).toHaveCSS('background-color', 'rgb(243, 242, 241)');
+        await expect(elements['active-nav-element']).toHaveCSS('padding', '7px 30px 8px 10px');
+        await expect(elements['active-nav-element']).toHaveCSS('margin-bottom', '5px');
+        await expect(elements['active-nav-element']).toHaveCSS('cursor', 'pointer');
+        await expect(elements['active-nav-element']).toHaveCSS('font-weight', '700');
+        await expect(elements['active-nav-element']).toHaveCSS('color', 'rgb(0, 58, 105)');
+
+        // hover styles for an active nav item
+        await elements['active-nav-element-container'].hover();
+        await expect(elements['active-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(52, 124, 169)');
+    });
+
+});
+
+test.describe('Navigation Menu without Header', () => {
+    let elements = {};
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/demo/navigation-menu/no-header');
+        elements['container'] = page.getByTestId('navigation-menu-container');
+        elements['nav-link-containers'] = elements['container'].locator('li');
+    });
+});
+

--- a/browser-tests/regression-tests/tests/nav-menu.spec.ts
+++ b/browser-tests/regression-tests/tests/nav-menu.spec.ts
@@ -73,8 +73,63 @@ test.describe('Navigation Menu without Header', () => {
     let elements = {};
     test.beforeEach(async ({ page }) => {
         await page.goto('/demo/navigation-menu/no-header');
+
         elements['container'] = page.getByTestId('navigation-menu-container');
+        elements['nav-container'] = elements['container'].locator('nav');
         elements['nav-link-containers'] = elements['container'].locator('li');
+        elements['inactive-nav-element-container'] = elements['nav-link-containers'].locator('nth=0');
+        elements['inactive-nav-element'] = elements['inactive-nav-element-container'].locator('a');
+        elements['active-nav-element-container'] = elements['nav-link-containers'].locator('nth=2');
+        elements['active-nav-element'] = elements['active-nav-element-container'].locator('a');
+    });
+
+    test('No Header', async ({ page }) => {
+        await expect(elements['container'].locator('h2')).toHaveCount(0);
+    });
+
+    test('Containers', async ({ page }) => {
+
+        // the container for the whole nav
+        await expect(elements['container']).toHaveCSS('padding-left', '15px');
+        await expect(elements['container']).toHaveCSS('padding-right', '15px');
+
+        // the container for the collection of nav itmes
+        await expect(elements['nav-container']).toHaveCSS('margin-left', '-15px');
+        await expect(elements['nav-container']).toHaveCSS('padding-left', '15px');
+    });
+
+    test('Nav items', async ({ page }) => {
+
+        await expect(elements['nav-link-containers']).toHaveCount(16);
+
+        // an inactive (not current page) nav item
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(177, 180, 182)');
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('margin-bottom', '8px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('padding', '7px 30px 8px 10px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('margin-bottom', '5px');
+        await expect(elements['inactive-nav-element']).toHaveCSS('cursor', 'pointer');
+        await expect(elements['inactive-nav-element']).toHaveCSS('font-weight', '400');
+
+        // hover styles for an inactive nav item
+        await elements['inactive-nav-element-container'].hover();
+        await expect(elements['inactive-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(52, 124, 169)');
+    });
+
+    test('Active nav item', async ({ page }) => {
+
+        // an active (current page) nav item
+        await expect(elements['active-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(0, 58, 105)');
+        await expect(elements['active-nav-element-container']).toHaveCSS('margin-bottom', '8px');
+        await expect(elements['active-nav-element-container']).toHaveCSS('background-color', 'rgb(243, 242, 241)');
+        await expect(elements['active-nav-element']).toHaveCSS('padding', '7px 30px 8px 10px');
+        await expect(elements['active-nav-element']).toHaveCSS('margin-bottom', '5px');
+        await expect(elements['active-nav-element']).toHaveCSS('cursor', 'pointer');
+        await expect(elements['active-nav-element']).toHaveCSS('font-weight', '700');
+        await expect(elements['active-nav-element']).toHaveCSS('color', 'rgb(0, 58, 105)');
+
+        // hover styles for an active nav item
+        await elements['active-nav-element-container'].hover();
+        await expect(elements['active-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(52, 124, 169)');
     });
 });
 


### PR DESCRIPTION
This adds regression tests for navigation menu comonents, with and without a header.
It also adds regression tests missed earlier for the hero banner when displayed on a narrow viewport