### PR TITLE
Whitespace fix for links created by Page Content Item components

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_PageContentsItem.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_PageContentsItem.cshtml
@@ -5,7 +5,7 @@
 @model PageContentsItem
 
 <li>
-    <a href="#swcd-contents-anchor-@Model.AnchorLink" class="govuk-link">
+    <a href="#swcd-contents-anchor-@Model.AnchorLink.Trim()" class="govuk-link">
         @Model.ItemText
     </a>
 </li>


### PR DESCRIPTION
Firefox has a problem with anchor links that have whitespace on the end of the href.  This PR fixes that