### PR TITLE
Breadcrumb restructure

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_BreadcrumbTrail.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_BreadcrumbTrail.cshtml
@@ -49,11 +49,13 @@
             default:
                 @foreach(KeyValuePair<string, string> trailItem in breadcrumbs)
                 {
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link" href="/@trailItem.Value">
-                            @trailItem.Key
-                        </a>
-                    </li>
+                    if (@trailItem.Value != @Model.Id) {
+                        <li class="govuk-breadcrumbs__list-item">
+                            <a class="govuk-breadcrumbs__link" href="/@trailItem.Value">
+                                @trailItem.Key
+                            </a>
+                        </li>
+                    }
                 }
             break;
         }


### PR DESCRIPTION
This PR restructures the breadcrumb link trail in line with accessibility guidelines, by removing the "current" page from the end of the trail