### PR TITLE
fix: ensure Pathways training content pages use breadcrumbs, per design

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_PageBanner.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_PageBanner.cshtml
@@ -4,7 +4,8 @@
 
 @if (Model != null && Model.ShowContentHeader)
 {
-    var useBreadcrumbs = ((ContextModel)ViewData["ContextModel"]).BreadcrumbTrail.Count() > 0;
+    var useBreadcrumbs = ((ContextModel)ViewData["ContextModel"]).BreadcrumbTrail.Count() > 0 
+        || Model.PageType == PageType.PathwaysTrainingContent;
     var textCss = "govuk-grid-column-three-quarters-from-desktop govuk-!-padding-top-4";
     textCss += useBreadcrumbs
         ? " page-banner-with-breadcrumbs"


### PR DESCRIPTION
This PR ensures that as per the designs for Pathways, that the actual training content pages show the breadcrumbs that are intended